### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/keyspace.go
+++ b/keyspace.go
@@ -142,7 +142,7 @@ func (k *k) FlexMultiTimeSeriesTable(name, timeField, idField string, indexField
 	}
 }
 
-// Returns table names in a keyspace
+// Tables returns table names in a keyspace
 func (k *k) Tables() ([]string, error) {
 	const stmt = "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name = ?"
 	maps, err := k.qe.Query(stmt, k.name)

--- a/options.go
+++ b/options.go
@@ -56,7 +56,7 @@ type Options struct {
 	Compressor string
 }
 
-// Returns a new Options which is a right biased merge of the two initial Options.
+// Merge returns a new Options which is a right biased merge of the two initial Options.
 func (o Options) Merge(neu Options) Options {
 	ret := Options{
 		TTL:             o.TTL,


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._